### PR TITLE
Feature/avvisninger endepunkt

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,7 +40,7 @@ dependencies {
     runtimeOnly("ch.qos.logback:logback-classic")
     runtimeOnly("net.logstash.logback:logstash-logback-encoder:${logbackEncoderVersion}")
     implementation("io.micronaut:micronaut-validation")
-    runtimeOnly("com.fasterxml.jackson.module:jackson-module-kotlin:2.13.4")
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.13.4")
 
     //Snyk fixes
     implementation("org.apache.kafka:kafka-clients:3.3.1")

--- a/naiserator.yml
+++ b/naiserator.yml
@@ -42,6 +42,7 @@ spec:
     inbound:
       rules:
         - application: pam-ad-api
+        - application: pam-ad
   ingresses:
   {{#each ingress as |url|}}
      - {{url}}

--- a/src/main/kotlin/no/nav/arbeidsplassen/stihibi/Avvisning.kt
+++ b/src/main/kotlin/no/nav/arbeidsplassen/stihibi/Avvisning.kt
@@ -1,9 +1,7 @@
 package no.nav.arbeidsplassen.stihibi
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import java.time.LocalDateTime
 
-@JsonIgnoreProperties(ignoreUnknown = true)
 data class Avvisning(
     val adUuid: String,
     val remarks: List<RemarkType>?,

--- a/src/main/kotlin/no/nav/arbeidsplassen/stihibi/Avvisning.kt
+++ b/src/main/kotlin/no/nav/arbeidsplassen/stihibi/Avvisning.kt
@@ -1,0 +1,23 @@
+package no.nav.arbeidsplassen.stihibi
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import java.time.LocalDateTime
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class Avvisning(
+    val adUuid: String,
+    val remarks: List<RemarkType>?,
+    val reportee: String?,
+    val avvist_tidspunkt: LocalDateTime
+)
+
+enum class RemarkType {
+    NOT_APPROVED_BY_LABOUR_INSPECTION,
+    NO_EMPLOYMENT,
+    DUPLICATE,
+    DISCRIMINATING,
+    REJECT_BECAUSE_CAPACITY,
+    FOREIGN_JOB,
+    COLLECTION_JOB,
+    UNKNOWN
+}

--- a/src/main/kotlin/no/nav/arbeidsplassen/stihibi/BigQueryService.kt
+++ b/src/main/kotlin/no/nav/arbeidsplassen/stihibi/BigQueryService.kt
@@ -71,7 +71,7 @@ class BigQueryService(
             SELECT
                 uuid as adUuid, 
                 JSON_EXTRACT(json, '$.administration.remarks') as remarks, 
-                JSON_EXTRACT(json, '$.administration.reportee') as reportee, 
+                JSON_EXTRACT_SCALAR(json, '$.administration.reportee') as reportee,
                 updated as avvist_tidspunkt 
             FROM `${tableFNAME}` 
             WHERE 

--- a/src/main/kotlin/no/nav/arbeidsplassen/stihibi/BigQueryService.kt
+++ b/src/main/kotlin/no/nav/arbeidsplassen/stihibi/BigQueryService.kt
@@ -76,8 +76,7 @@ class BigQueryService(
             FROM `${tableFNAME}` 
             WHERE 
                 status='REJECTED' 
-                and created >= DATETIME_SUB(CURRENT_DATETIME(), INTERVAL 1 YEAR)
-            LIMIT 10;
+                and created >= DATETIME_SUB(CURRENT_DATETIME(), INTERVAL 1 YEAR);
         """.trimIndent()
 
         val queryConfig = QueryJobConfiguration.newBuilder(query).build()

--- a/src/main/kotlin/no/nav/arbeidsplassen/stihibi/BigQueryService.kt
+++ b/src/main/kotlin/no/nav/arbeidsplassen/stihibi/BigQueryService.kt
@@ -87,7 +87,7 @@ class BigQueryService(
                 adUuid = it["adUuid"].value.toString(),
                 remarks = objectMapper.readValue<List<RemarkType>>(it["remarks"].value.toString()),
                 reportee = it["reportee"].value.toString(),
-                avvist_tidspunkt = objectMapper.readValue(it["avvist_tidspunkt"].value.toString(), LocalDateTime::class.java)
+                avvist_tidspunkt = LocalDateTime.parse(it["avvist_tidspunkt"].value.toString())
             )
         }
     }

--- a/src/main/kotlin/no/nav/arbeidsplassen/stihibi/api/v1/AdAvvisningContoller.kt
+++ b/src/main/kotlin/no/nav/arbeidsplassen/stihibi/api/v1/AdAvvisningContoller.kt
@@ -1,0 +1,20 @@
+package no.nav.arbeidsplassen.stihibi.api.v1
+
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import no.nav.arbeidsplassen.stihibi.Avvisning
+import no.nav.arbeidsplassen.stihibi.BigQueryService
+import org.slf4j.LoggerFactory
+
+@Controller("/api/v1/ads/avvisning")
+class AdAvvisningContoller(private val bigQueryService: BigQueryService) {
+    companion object {
+        private val LOG = LoggerFactory.getLogger(AdAvvisningContoller::class.java)
+    }
+
+    @Get
+    fun retrieveAdHistory(): List<Avvisning> {
+        LOG.info("Henter alle avvisninger det siste året")
+        return bigQueryService.queryAvvisning()
+    }
+}


### PR DESCRIPTION
Endepunkt for å hente alle avvisninger det siste året fra bigquery.

Tenkt til å brukes for å populere Avvising-tabellen i pam-ad med tidligere avvisninger.

Per nå henter jeg bare 10 slik at jeg kan teste uten å kjøre BQ-kostnadene i været.